### PR TITLE
17: Add hook when post meta is copied to cloned post.

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -183,6 +183,13 @@ class Cloner {
 				add_post_meta( $post_id, $key, $value );
 			}
 		}
+
+		/**
+		 * Fires when post meta has been copied to cloned post.
+		 *
+		 * @param array $post_id Post ID of cloned post.
+		 */
+		do_action( 'post_cloner_after_meta_data_copy', $post_id );
 	}
 
 	/**


### PR DESCRIPTION
#17 

@mikeselander - this is the lightest footprint hook/action I could think of to give us what we needed for our purpose.

When this hook fires we check the cloned post for a fixed array of meta keys, which we manually unserialize to resolve #17.

**Suggested usage**

Hook
```
	add_action( 'post_cloner_after_meta_data_copy', __NAMESPACE__ . '\\clean_cloned_post_meta' );
```
Function
```
function clean_cloned_post_meta( $post_ID ) {
        ....
	// Loop through keys to clean and unserialize. Store only if result is an array.
	foreach ( $keys_to_clean as $key => $value ) {
		if ( ! empty( get_post_meta( $post_ID, $value, true ) ) ) {
			$unserialized_meta = maybe_unserialize( get_post_meta( $post_ID, $value, true ) );
			if ( ! is_array( $unserialized_meta ) ) {
				continue;
			}
			update_post_meta( $post_ID, $value, $unserialized_meta );
		}
	}
}
```

Would you mind to review approach for me @mikeselander?

