### PR TITLE
Fix issues with translations not working

### DIFF
--- a/assets/js/gutenberg.js
+++ b/assets/js/gutenberg.js
@@ -1,5 +1,6 @@
 /* global postCloner, wp */
 /* eslint no-var: off */
+const { __, sprintf } = wp.i18n;
 
 /**
  * WordPress React element creation entry point.
@@ -18,7 +19,8 @@ function getContent() {
 			className: 'components-button is-button is-large is-default',
 			href: postCloner.cloneLink,
 		},
-		wp.i18n.__( 'Clone ' + postCloner.postTypelabels.singular_name )
+		// translators: %s Post name.
+		sprintf( __( 'Clone %s', 'post-cloner' ), postCloner.postTypelabels.singular_name )
 	);
 }
 

--- a/assets/js/gutenberg.js
+++ b/assets/js/gutenberg.js
@@ -1,6 +1,5 @@
 /* global postCloner, wp */
 /* eslint no-var: off */
-const { __, sprintf } = wp.i18n;
 
 /**
  * WordPress React element creation entry point.
@@ -20,7 +19,7 @@ function getContent() {
 			href: postCloner.cloneLink,
 		},
 		// translators: %s Post name.
-		sprintf( __( 'Clone %s', 'post-cloner' ), postCloner.postTypelabels.singular_name )
+		wp.i18n.sprintf( wp.i18n.__( 'Clone %s', 'post-cloner' ), postCloner.postTypelabels.singular_name )
 	);
 }
 

--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -95,11 +95,13 @@ final class Admin {
 		wp_enqueue_script(
 			'post-cloner-gutenberg',
 			$this->definitions->assets_url . '/js/gutenberg.js',
-			[ 'wp-blocks', 'wp-element', 'wp-url', 'wp-components', 'wp-editor' ],
+			[ 'wp-blocks', 'wp-element', 'wp-url', 'wp-components', 'wp-editor', 'wp-i18n' ],
 			$this->definitions->version
 		);
 
 		$post_type = get_post_type_object( get_post( $post_id )->post_type );
+
+		wp_set_script_translations( 'post-cloner-gutenberg', 'post-cloner' );
 
 		// Load up data about said post.
 		wp_localize_script(


### PR DESCRIPTION
@mikeselander This PR does the following:
- Updates translation support for Gutenberg 5.*
- Adds in `sprintf` for use with `__`

Code to run to generate language files:
```
wp i18n make-pot . post-cloner-ja.po --domain=post-cloner
```

```
wp i18n make-json post-cloner-ja.po --no-purge
```

@abhishek-kaushik Can you please test these changes locally. After running the `make-json` command above you should now get `Success: Created 1 file.`