### PR TITLE
To render nothing, return null.

### DIFF
--- a/assets/js/gutenberg.js
+++ b/assets/js/gutenberg.js
@@ -26,7 +26,7 @@ function getContent() {
 /**
  * Display a custom status fill element at the bottom of the G'berg post status box.
  *
- * @returns {Function} createElement instance.
+ * @returns {Function|null} createElement instance.
  */
 function DisplayPostCloningStatus() {
 	// If user cannot clone, or post is not clonable, do nothing.

--- a/assets/js/gutenberg.js
+++ b/assets/js/gutenberg.js
@@ -31,7 +31,7 @@ function getContent() {
 function DisplayPostCloningStatus() {
 	// If user cannot clone, or post is not clonable, do nothing.
 	if ( ! postCloner.userCanClone || ! postCloner.postIsClonable ) {
-		return;
+		return null;
 	}
 
 	return el(


### PR DESCRIPTION
DisplayPostCloningStatus(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.