### PR TITLE
Preparing composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,7 @@
 {
-  "name": "Post Cloner",
-  "version": "1.1.0",
+  "name": "humanmade/post-cloner",
   "type": "wordpress-plugin",
   "license": "GPL-3.0-or-later",
-  "config": {
-    "autoloader-suffix": "DontChange"
-  },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
     "humanmade/coding-standards": "dev-master"


### PR DESCRIPTION
Fixing the package name so we can add it to packagist and removing autoload suffix as I can see no reason as to why it was specified.

**This PR is to prepare the plugin to be submitted to packagist.org so we can pull it in via composer without setting a custom repository.**