### PR TITLE
Use original post parent ID as cloned parent ID

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -47,9 +47,9 @@ class Cloner {
 		/**
 		 * Parent that the new post should have.
 		 *
-		 * @param int $parent Parent - defaults to original post ID.
+		 * @param int $parent Parent - defaults to original post parent ID.
 		 */
-		$parent = apply_filters( 'post_cloner_cloned_parent', $original_post['ID'] );
+		$parent = apply_filters( 'post_cloner_cloned_parent', $original_post['post_parent'] );
 
 		// Set the post_parent.
 		$duplicate_post['post_parent'] = $parent;


### PR DESCRIPTION
fixes #8 
Don't set the cloned post parent ID to the original post ID, just use the original post's parent ID. But still allow filtering