### PR TITLE
Post parent should be identical

### DIFF
--- a/tests/test-post-cloner.php
+++ b/tests/test-post-cloner.php
@@ -149,7 +149,6 @@ class TestPostCloner extends PostCloner_TestCase {
 			'post_modified',
 			'post_modified_gmt',
 			'post_status',       // New post is always draft.
-			'post_parent',       // New post now has original post as parent.
 			'ancestors',         // See above note.
 		];
 


### PR DESCRIPTION
Following the change to `post_parent` value in cloned post, the test should reflect that