### PR TITLE
Check whether to strip the suffix from preview permalink

### DIFF
--- a/inc/class-rewrites.php
+++ b/inc/class-rewrites.php
@@ -57,7 +57,7 @@ final class Rewrites {
 	 * @return string Potentially modified permalink.
 	 */
 	public function strip_cloned_from_url_preview( $output, $post_id ) {
-		if ( is_post_cloned( $post_id ) ) {
+		if ( is_post_cloned( $post_id ) && strip_cloned( $output, get_post( $post_id ) ) ) {
 			$output = preg_replace( '/(' . $this->search_string . ')/', '', $output, 1 );
 		}
 


### PR DESCRIPTION
Not sure if this was intentionally missed so will wait for your input here.

I think in the `strip_cloned()` function signature we might need to remove the `WP_Post` type hint too because the result of `get_post()` or the post object passed to it might not always be a `WP_Post` object, it'd be better to do a check and avoid the potential fatal error.